### PR TITLE
fix(core): fix value.lifeSpan is undefined

### DIFF
--- a/packages/@ngx-cache/core/src/cache.service.ts
+++ b/packages/@ngx-cache/core/src/cache.service.ts
@@ -66,7 +66,7 @@ export class CacheService {
     const normalized = CacheService.normalizeKey(key);
     const cached = this.cache.getItem(normalized);
 
-    if (cached) {
+    if (Object.entries(cached).length !== 0 && cached.constructor === Object) {
       if (CacheService.validateValue(cached)) {
         return cached.data;
       } else {
@@ -81,7 +81,7 @@ export class CacheService {
     const normalized = CacheService.normalizeKey(key);
     const cached = this.cache.getItem(normalized);
 
-    if (cached) {
+    if (Object.entries(cached).length !== 0 && cached.constructor === Object) {
       if (CacheService.validateValue(cached)) {
         return cached;
       } else {


### PR DESCRIPTION
** PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/fulls1z3/ngx-cache/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

** PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

** What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

** What is the new behavior?

** Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

** Other information

When calling `CachedService.get('*')` or `CachedService.getWithMetadata('*')` with a key that has no cached data, the `const cached` returns an empty object `{}` which leads to the following error in the browser.

```
ERROR TypeError: "value.lifeSpan is undefined"
    validateValue ngx-cache-core.js:61
    getWithMetadata ngx-cache-core.js:95
```
Solution: make sure it's not an empty object.