### PR TITLE
fix(core): changes Cache.has to also check if the cache is expired

### DIFF
--- a/packages/@ngx-cache/core/src/cache.service.ts
+++ b/packages/@ngx-cache/core/src/cache.service.ts
@@ -49,7 +49,7 @@ export class CacheService {
   has(key: string | number): boolean {
     const normalized = CacheService.normalizeKey(key);
 
-    return this.cache.keys.indexOf(normalized) !== -1;
+    return this.cache.keys.indexOf(normalized) !== -1 && CacheService.validateValue(this.cache.getItem(normalized));
   }
 
   set(key: string | number, value: any, returnType: ReturnType = ReturnType.Scalar, lifeSpan?: LifeSpan): boolean {


### PR DESCRIPTION
Changes `Cache.has` function to say that an item in the cache does not exists if it has expired.

Closes #125

** PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/fulls1z3/ngx-cache/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

** PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

** What is the current behavior?

When calling Cache.has('someKey') it only looks if the key exists, not if it has expired.

Issue Number: #125 

** What is the new behavior?

If the item in the cache has expired then the Cache.has method returns false.

** Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```